### PR TITLE
tqdm is required but not listed in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ jupyter
 asyncio
 GitPython
 pycocotools
+tqdm


### PR DESCRIPTION
**Command to reproduce the issue:**

`docker run -it --rm -v $(pwd):/app -w /app tensorflow/tensorflow:latest-py3 \
 bash -c "apt install -y git libsm6 libxrender1 && pip install cython numpy && pip install -r requirements.txt && python -c 'import NomeroffNet'"` 

**Command's output:**
```
WARNING: You are using pip version 19.1.1, however version 19.2.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/NomeroffNet/__init__.py", line 1, in <module>
    from .mcm import *
  File "/app/NomeroffNet/mcm/__init__.py", line 1, in <module>
    from .mcm import *
  File "/app/NomeroffNet/mcm/mcm.py", line 4, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```