### PR TITLE
bug with augmented images fixed

### DIFF
--- a/NomeroffNet/Base/TextImageGenerator.py
+++ b/NomeroffNet/Base/TextImageGenerator.py
@@ -117,6 +117,8 @@ class TextImageGenerator:
                 self.imgs[i, :, :] = img
                 self.texts.append(text)
             aug_count -= 1
+        self.n = len(self.imgs)
+        self.indexes = list(range(self.n))
 
 
     def get_output_size(self):


### PR DESCRIPTION
Hello.

Noticed a bug in TextImageGenerator that when augmentation for training is on, augmented images will not be used while training anyway. It was because self.n and self.indexes variables were not updated after adding augmented images to self.imgs, and when you take self.imgs[self.indexes[self.cur_index]] as next image in train sampling, it never reaches indices of augmented images.

So added two lines of code that fix it.