### PR TITLE
Fix imgaug version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 setuptools
 numpy>=1.16.*
-imgaug==4.*
+imgaug==0.4.*
 tensorflow>=2.3.*
 opencv_python
 scikit_image


### PR DESCRIPTION
The latest available version is 0.4.x, not 4.x.

https://pypi.org/project/imgaug/