### PR TITLE
Update README.md - optionsDetector.predict

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ all_points = npPointsCraft.detect(img, targetBoxes,[5,2,0])
 zones = convertCvZonesRGBtoBGR([getCvZoneRGB(img, reshapePoints(rect, 1)) for rect in all_points])
 
 # predict zones attributes 
-regionIds, stateIds, countLines = optionsDetector.predict(zones)
+regionIds, countLines = optionsDetector.predict(zones)
 regionNames = optionsDetector.getRegionLabels(regionIds)
 
 # find text with postprocessing by standart


### PR DESCRIPTION
`optionsDetector.predict(zones)` with default arguments returns only 2 items, not 3.

Reference: 
https://github.com/ria-com/nomeroff-net/blob/d38565f15d737149274f4f673b820440fc52b21a/examples/py/get-started-demo.py#L49