### PR TITLE
fix version name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 setuptools
 numpy==1.23.5
-imgaug>=0.4.*
+imgaug>=0.4.0
 opencv_python
 scikit_image
 asyncio


### PR DESCRIPTION
To avoid the problem with `pip install .` that results in the following error:

```
'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```